### PR TITLE
CI: disable VS2017 build

### DIFF
--- a/.github/workflows/build-msbuild.yaml
+++ b/.github/workflows/build-msbuild.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         sln:
-          - vs2017
+          #- vs2017
           - vs2015
 
     steps:


### PR DESCRIPTION
Windows-latest image VS dropped a bunch of tools and it's non-trivial to fix. Use VS2015 build instead or build yourself.