### PR TITLE
Fix possible crashes and unexpected return values

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,6 +116,22 @@ jobs:
           compression-level: 9
           if-no-files-found: 'error'
 
+  type-check-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: >
+          pip install
+          -r test/requirements.txt
+          -r test/requirements-dev.txt
+
+      - name: Type-check
+        run: >
+          mypy --strict test/
+
   coverage-report:
     needs: test
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -102,14 +102,6 @@ If a game needs to be connected at all times, not receiving SlotConnected within
 of a failed connect / connect timeout. Receiving a disconnect or error after being connected would be a lost connection.
 
 
-# Known Problems
-
-* Calling certain methods while not connected can lead to unhandled C++ exceptions (crash).
-* Inconsistencies between errors and return false when supplying bad argument.
-
-See test/ for reproducers.
-
-
 ## To-Do
 
 * Full build matrix
@@ -118,7 +110,6 @@ See test/ for reproducers.
   * MSVC builds - currently there is only 32bit and there is no static Lua5.1 build
 * Bundle CA certs
 * UUID helper - currently uuid is not being used, so you can just pass in an empty string
-* Fix known problems.
 
 
 ## Downloads

--- a/build_posix.sh
+++ b/build_posix.sh
@@ -28,7 +28,7 @@ else
     EXTRA_LIBS="-Wl,-Bdynamic $EXTRA_LIBS_DYNAMIC"
 fi
 
-CFLAGS="-Os -DNDEBUG -std=$STD -Wno-deprecated-declarations $EXTRA_CFLAGS $CFLAGS"
+CFLAGS="-Os -DNDEBUG -std=$STD -Wall -Wextra -Werror -Wno-deprecated-declarations $EXTRA_CFLAGS $CFLAGS"
 
 OUT="$FILENAME"
 

--- a/src/lua-apclientpp.cpp
+++ b/src/lua-apclientpp.cpp
@@ -59,13 +59,16 @@ static void print(lua_State *L, const std::string& line)
         fprintf(stderr, "Could not call Lua print!\n");
     }
 }
+
 static void errorf(lua_State *L, const char* fmt, ...)
 {
     char buf[1024];
     va_list args;
     va_start (args, fmt);
     auto res = vsnprintf(buf, sizeof(buf), fmt, args);
-    if (res >= sizeof(buf))
+    if (res < 0)
+        strcpy(buf, "Error formatting error");
+    else if ((size_t)res >= sizeof(buf))
         memcpy(buf + sizeof(buf) - 4, "...", 4);
     print(L, buf);
     va_end (args);
@@ -537,7 +540,7 @@ public:
             }
             APClient* parent = self;
             parent->poll();
-        } catch (std::exception ex) {
+        } catch (const std::exception& ex) {
             self->push_error(ex.what());
         }
 

--- a/src/lua-apclientpp.cpp
+++ b/src/lua-apclientpp.cpp
@@ -1322,22 +1322,25 @@ static int apclient_LocationScouts(lua_State *L)
             create_as_hints = (int)luaL_checkinteger(L, 3);
     }
 
-    {
+    try {
         std::list<int64_t> locations;
         {
             json j = lua_to_json(L, 2);
             try {
                 locations = j.get<std::list<int64_t>>();
-            } catch (std::exception ex) {
+            } catch (const std::exception&) {
                 if (!j.is_object() || !j.empty()) {
-                    errorf(L, "Invalid argument for locations");
-                    return 0;
+                    throw BadArgumentException(2, "array of integer", "LocationScouts");
                 }
             }
         }
         lua_pushboolean(L, self->LocationScouts(locations, create_as_hints));
         return 1;
+    } catch (const std::exception& ex) {
+        lua_pushstring(L, ex.what());
     }
+    lua_error(L);
+    return 0; // LCOV_EXCL_LINE // unreachable
 }
 
 static int apclient_Get(lua_State *L)

--- a/src/lua-apclientpp.cpp
+++ b/src/lua-apclientpp.cpp
@@ -506,9 +506,8 @@ public:
         std::list<std::string> keys;
         try {
             keys = j.get<std::list<std::string>>();
-        } catch (std::exception ex) {
-            print_error("Invalid argument for keys");
-            return false;
+        } catch (const std::exception&) {
+            throw BadArgumentException(2, "array of string", "SetNotify");
         }
 
         APClient* parent = this;
@@ -1358,10 +1357,11 @@ static int apclient_SetNotify(lua_State *L)
     try {
         lua_pushboolean(L, self->SetNotify(lua_to_json(L, 2)));
         return 1;
-    } catch (std::exception ex) {
-        errorf(L, "SetNotify failed: %s", ex.what());
-        return 0;
+    } catch (const std::exception& ex) {
+        lua_pushstring(L, ex.what());
     }
+    lua_error(L);
+    return 0; // LCOV_EXCL_LINE // unreachable
 }
 
 static int apclient_Set(lua_State *L)

--- a/src/lua-apclientpp.cpp
+++ b/src/lua-apclientpp.cpp
@@ -14,11 +14,15 @@
 
 #ifndef _MSC_VER
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas" // gcc doesn't know -Wunknown-warning-option
 #pragma GCC diagnostic ignored "-Wunknown-warning-option" // clang doesn't know -Wtemplate-id-cdtor
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wtemplate-id-cdtor"
 #pragma GCC diagnostic ignored "-Wnull-pointer-subtraction"
 #pragma GCC diagnostic ignored "-Wdeprecated-literal-operator"
+#ifdef _WIN32
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
 #endif
 
 extern "C" {

--- a/src/lua-apclientpp.cpp
+++ b/src/lua-apclientpp.cpp
@@ -468,10 +468,9 @@ public:
         std::list<int64_t> locations;
         try {
             locations = j.get<std::list<int64_t>>();
-        } catch (std::exception ex) {
+        } catch (const std::exception&) {
             if (!j.is_object() || !j.empty()) {
-                print_error("Invalid argument for locations");
-                return false;
+                throw BadArgumentException(2, "array of integer", "LocationChecks");
             }
         }
 
@@ -1301,8 +1300,14 @@ static int apclient_StatusUpdate(lua_State *L)
 static int apclient_LocationChecks(lua_State *L)
 {
     LuaAPClient *self = LuaAPClient::luaL_checkthis(L, 1);
-    lua_pushboolean(L, self->LocationChecks(lua_to_json(L, 2)));
-    return 1;
+    try {
+        lua_pushboolean(L, self->LocationChecks(lua_to_json(L, 2)));
+        return 1;
+    } catch (const std::exception& ex) {
+        lua_pushstring(L, ex.what());
+    }
+    lua_error(L);
+    return 0; // LCOV_EXCL_LINE // unreachable
 }
 
 static int apclient_LocationScouts(lua_State *L)

--- a/src/lua-apclientpp.cpp
+++ b/src/lua-apclientpp.cpp
@@ -1368,31 +1368,31 @@ static int apclient_Set(lua_State *L)
 {
     LuaAPClient *self = LuaAPClient::luaL_checkthis(L, 1);
     const char* key = luaL_checkstring(L, 2);
-    json dflt = lua_to_json(L, 3);
     luaL_checkany(L, 4);
-    bool want_reply = lua_toboolean(L, 4);
-
-    std::list<APClient::DataStorageOperation> operations;
     try {
-        lua_to_json(L, 5).get_to(operations);
-    } catch (std::exception) {
-        errorf(L, "Invalid argument for operations");
-        return 0;
-    }
+        json dflt = lua_to_json(L, 3);
+        bool want_reply = lua_toboolean(L, 4);
 
-    json extras;
-    if (lua_gettop(L) >= 6) {
-        extras = lua_to_json(L, 6);
-    }
+        std::list<APClient::DataStorageOperation> operations;
+        try {
+            lua_to_json(L, 5).get_to(operations);
+        } catch (const std::exception&) {
+            throw BadArgumentException(5, "array of operations", "Set");
+        }
 
-    try {
+        json extras;
+        if (lua_gettop(L) >= 6) {
+            extras = lua_to_json(L, 6);
+        }
+
         bool res = self->Set(key, dflt, want_reply, operations, extras);
         lua_pushboolean(L, res);
         return 1;
-    } catch (std::exception ex) {
-        errorf(L, "Set failed: %s", ex.what());
-        return 0;
+    } catch (const std::exception& ex) {
+        lua_pushstring(L, ex.what());
     }
+    lua_error(L);
+    return 0; // LCOV_EXCL_LINE // unreachable
 }
 
 static int apclient_poll(lua_State *L)

--- a/src/lua-apclientpp.cpp
+++ b/src/lua-apclientpp.cpp
@@ -1230,47 +1230,50 @@ static int apclient_ConnectUpdate(lua_State *L)
 static int apclient_Bounce(lua_State *L)
 {
     LuaAPClient *self = LuaAPClient::luaL_checkthis(L, 1);
-    json data = lua_to_json(L, 2);
-    std::list<std::string> games;
-    std::list<int> slots;
-    std::list<std::string> tags;
+    try {
+        json data = lua_to_json(L, 2);
+        std::list<std::string> games;
+        std::list<int> slots;
+        std::list<std::string> tags;
 
-    if (lua_gettop(L) >= 3) {
-        try {
-            auto j = lua_to_json(L, 3);
-            if (j.size() > 0)
-                games = j.get<std::list<std::string>>();
-        } catch (std::exception) {
-            errorf(L, "Invalid games argument");
-            return 0;
+        if (lua_gettop(L) >= 3) {
+            try {
+                auto j = lua_to_json(L, 3);
+                if (j.size() > 0)
+                    games = j.get<std::list<std::string>>();
+            } catch (const std::exception&) {
+                throw BadArgumentException(3, "optional array of string", "Bounce");
+            }
         }
-    }
 
-    if (lua_gettop(L) >= 4) {
-        try {
-            auto j = lua_to_json(L, 4);
-            if (j.size() > 0)
-                slots = j.get<std::list<int>>();
-        } catch (std::exception) {
-            errorf(L, "Invalid slots argument");
-            return 0;
+        if (lua_gettop(L) >= 4) {
+            try {
+                auto j = lua_to_json(L, 4);
+                if (j.size() > 0)
+                    slots = j.get<std::list<int>>();
+            } catch (const std::exception&) {
+                throw BadArgumentException(4, "optional array of integer", "Bounce");
+            }
         }
-    }
 
-    if (lua_gettop(L) >= 5) {
-        try {
-            auto j = lua_to_json(L, 5);
-            if (j.size() > 0)
-                tags = j.get<std::list<std::string>>();
-        } catch (std::exception) {
-            errorf(L, "Invalid tags argument");
-            return 0;
+        if (lua_gettop(L) >= 5) {
+            try {
+                auto j = lua_to_json(L, 5);
+                if (j.size() > 0)
+                    tags = j.get<std::list<std::string>>();
+            } catch (const std::exception&) {
+                throw BadArgumentException(5, "optional array of string", "Bounce");
+            }
         }
-    }
 
-    bool res = self->Bounce(data, games, slots, tags);
-    lua_pushboolean(L, res);
-    return 1;
+        bool res = self->Bounce(data, games, slots, tags);
+        lua_pushboolean(L, res);
+        return 1;
+    } catch (const std::exception& ex) {
+        lua_pushstring(L, ex.what());
+    }
+    lua_error(L);
+    return 0; // LCOV_EXCL_LINE // unreachable
 }
 
 static int apclient_Say(lua_State *L)

--- a/test/README.md
+++ b/test/README.md
@@ -65,8 +65,6 @@ What's missing from tests:
 * See TODOs in test_properties.py
 * Isolated tests for GetDataPackage. See server.py for a current bug.
 * All the things in render_json
-* Figure out why running ConnectSlot while not connected crashes
-  * see `@skipIf(True, ...)`
 * Test more function calls while not connected
 * Fuzz/test behavior when server is sending garbage
 * call that triggers assign_set and contains

--- a/test/README.md
+++ b/test/README.md
@@ -68,6 +68,5 @@ What's missing from tests:
 * Figure out why running ConnectSlot while not connected crashes
   * see `@skipIf(True, ...)`
 * Test more function calls while not connected
-* Crash in test_commands.py: TestGet: test_bad_extra
 * Fuzz/test behavior when server is sending garbage
 * call that triggers assign_set and contains

--- a/test/README.md
+++ b/test/README.md
@@ -65,6 +65,5 @@ What's missing from tests:
 * See TODOs in test_properties.py
 * Isolated tests for GetDataPackage. See server.py for a current bug.
 * All the things in render_json
-* Test more function calls while not connected
 * Fuzz/test behavior when server is sending garbage
 * call that triggers assign_set and contains

--- a/test/bases.py
+++ b/test/bases.py
@@ -125,6 +125,15 @@ class ClientTestCase(LuaTestCase):
             self.lua.gccollect()  # doesn't release the GIL? FIXME: explicit close() in the client?
 
 
+class NotConnectedTestCase(ClientTestCase):
+    def poll(self) -> None:
+        raise RuntimeError("Do not poll to stay disconnected")
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.connect()
+
+
 class E2ETestCase(ClientTestCase):
     slot: str = "Player1"
     items_handling: int = 0

--- a/test/requirements-dev.txt
+++ b/test/requirements-dev.txt
@@ -2,3 +2,5 @@
 pytest==8.4.2
 pytest-xdist==3.8.0
 gcovr==8.3
+mypy==1.18.2
+types-lupa==2.5.0.20250915

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -528,44 +528,40 @@ class TestSet(E2ETestCase):
 
     def test_missing_value(self) -> None:
         with self.assertRaises(LuaError):
-            res = self.call(
+            self.call(
                 "Set",
                 "a",
             )
-            self.assertFalse(res)
 
     def test_bad_key(self) -> None:
         with self.assertRaises(LuaError):
-            res = self.call(
+            self.call(
                 "Set",
                 self.lua.table(),
                 1,
                 False
             )
-            self.assertFalse(res)
 
     def test_bad_operations(self) -> None:
-        # FIXME: this should raise
-        res = self.call(
-            "Set",
-            "a",
-            1,
-            False,
-            1,
-        )
-        self.assertFalse(res)
+        with self.assertRaises(LuaError):
+            self.call(
+                "Set",
+                "a",
+                1,
+                False,
+                1,
+            )
 
     def test_bad_extra(self) -> None:
-        # FIXME: this should raise
-        res = self.call(
-            "Set",
-            "a",
-            1,
-            False,
-            self.lua.table(),
-            1,
-        )
-        self.assertFalse(res)
+        with self.assertRaises(LuaError):
+            self.call(
+                "Set",
+                "a",
+                1,
+                False,
+                self.lua.table(),
+                1,
+            )
 
 
 class TestSetNotConnected(NotConnectedTestCase):
@@ -575,7 +571,7 @@ class TestSetNotConnected(NotConnectedTestCase):
             "a",
             1,
             False,
-            self.lua.table(),
+            self.client["EMPTY_ARRAY"],
         )
         self.assertFalse(res)
 

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -583,19 +583,17 @@ class TestSetNotify(E2ETestCase):
             self.client["SetNotify"](self.lua.table())
 
     def test_missing_keys(self) -> None:
-        # FIXME: should this raise?
-        res = self.call(
-            "SetNotify",
-        )
-        self.assertFalse(res)
+        with self.assertRaises(LuaError):
+            self.call(
+                "SetNotify",
+            )
 
     def test_bad_keys(self) -> None:
-        # FIXME: should this raise?
-        res = self.call(
-            "SetNotify",
-            1,
-        )
-        self.assertFalse(res)
+        with self.assertRaises(LuaError):
+            self.call(
+                "SetNotify",
+                1,
+            )
 
 
 class TestSetNotifyNotConnected(NotConnectedTestCase):

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -277,8 +277,12 @@ class TestLocationScout(E2ETestCase):
             self.client["LocationScouts"](self.lua.table())
 
     def test_bad_locations(self) -> None:
-        res = self.call("LocationScouts", 1)
-        self.assertFalse(res)
+        with self.assertRaises(LuaError):
+            self.call("LocationScouts", 1)
+
+    def test_bad_create_as_hint(self) -> None:
+        with self.assertRaises(LuaError):
+            self.call("LocationScouts", self.lua.table(self.location_id), "bad")
 
 
 class TestLocationScoutNotConnected(NotConnectedTestCase):

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -153,6 +153,20 @@ class TestStatusUpdate(E2ETestCase):
         with self.assertRaises(LuaError):
             self.call("StatusUpdate", self.lua.table())
 
+    def test_too_small(self) -> None:
+        with self.assertRaises(LuaError):
+            self.call("StatusUpdate", -2**63)
+
+    def test_too_big(self) -> None:
+        # fits lua_Integer but not int
+        with self.assertRaises(LuaError):
+            self.call("StatusUpdate", 2**63 - 1)
+
+    def test_way_too_big(self) -> None:
+        # won't fit lua_Integer
+        with self.assertRaises(LuaError):
+            self.call("StatusUpdate", float(2**64))
+
 
 class TestStatusUpdateNotConnected(NotConnectedTestCase):
     def test_call(self) -> None:

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -1,5 +1,4 @@
 from typing import Any, Dict, Optional, cast
-from unittest import skipIf
 
 from .bases import E2ETestCase
 from .util import LuaError, LuaTable, TimeoutLoop
@@ -299,13 +298,12 @@ class TestGet(E2ETestCase):
             self.client["Get"](self.lua.table())
 
     def test_bad_keys(self) -> None:
-        res = self.call("Get", 1)
-        self.assertFalse(res)
+        with self.assertRaises(LuaError):
+            self.call("Get", 1)
 
-    @skipIf(True, "Crashes")
     def test_bad_extra(self) -> None:
-        res = self.call("Get", self.lua.table(*self.data.keys()), 1)
-        self.assertFalse(res)
+        with self.assertRaises(LuaError):
+            self.call("Get", self.lua.table(*self.data.keys()), 1)
 
 class TestSet(E2ETestCase):
     # also tests SetNotify and EmptyArray

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional, cast
 from unittest import skipIf
 
 from .bases import E2ETestCase
@@ -273,11 +273,11 @@ class TestGet(E2ETestCase):
                 self.assertTableEqualList(data[key], self.data[key])
             else:
                 self.assertEqual(data[key], self.data[key])
-        self.received_extra = {
+        self.received_extra = cast(Dict[str, Any], {
             k: v
             for k, v in command.items()
             if k not in ("cmd", "keys")
-        }
+        })
         self.done = True
 
     def test_get(self) -> None:
@@ -320,11 +320,11 @@ class TestSet(E2ETestCase):
     def on_set_reply(self, command: LuaTable) -> None:
         self.received_value = command["value"]
         self.received_original = command["original_value"]
-        self.received_extra = {
+        self.received_extra = cast(Dict[str, Any], {
             k: v
             for k, v in command.items()
             if k not in {"cmd", "key", "default", "value", "want_reply", "operations", "original_value", "slot"}
-        }
+        })
         self.done = True
 
     def data_as_table(self, data: Any) -> Any:
@@ -457,7 +457,7 @@ class TestSet(E2ETestCase):
         self.assertTrue(res)
         for _ in TimeoutLoop(lambda: not self.done):
             self.poll()
-        self.assertTableEqualList(self.received_value, [])
+        self.assertTableEqualList(cast(LuaTable, self.received_value), [])
         self.assertEqual(self.server.data_storage[key], [])
 
     def test_empty_dict(self) -> None:
@@ -472,7 +472,7 @@ class TestSet(E2ETestCase):
         self.assertTrue(res)
         for _ in TimeoutLoop(lambda: not self.done):
             self.poll()
-        self.assertTableEqualDict(self.received_value, {})
+        self.assertTableEqualDict(cast(LuaTable, self.received_value), {})
         self.assertEqual(self.server.data_storage[key], {})
 
     def test_bad_self(self) -> None:

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -149,6 +149,10 @@ class TestStatusUpdate(E2ETestCase):
         with self.assertRaises(LuaError):
             self.client["StatusUpdate"](self.lua.table())
 
+    def test_bad_status(self) -> None:
+        with self.assertRaises(LuaError):
+            self.call("StatusUpdate", self.lua.table())
+
 
 class TestStatusUpdateNotConnected(NotConnectedTestCase):
     def test_call(self) -> None:

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -23,6 +23,10 @@ class TestSay(E2ETestCase):
         with self.assertRaises(LuaError):
             self.client["Say"](self.lua.table())
 
+    def test_bad_text(self) -> None:
+        with self.assertRaises(LuaError):
+            self.call("Say", self.lua.table())
+
 
 class TestSayNotConnected(NotConnectedTestCase):
     def test_call(self) -> None:

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -76,34 +76,34 @@ class TestBounce(E2ETestCase):
             self.poll()
 
     def test_bad_game(self) -> None:
-        ok = self.call(
-            "Bounce",
-            self.lua.table(nonce = self.nonce),
-            1,
-            None,
-            None,
-        )
-        self.assertFalse(ok)
+        with self.assertRaises(LuaError):
+            self.call(
+                "Bounce",
+                self.lua.table(nonce = self.nonce),
+                1,
+                None,
+                None,
+            )
 
     def test_bad_slot(self) -> None:
-        ok = self.call(
-            "Bounce",
-            self.lua.table(nonce = self.nonce),
-            None,
-            1,
-            None,
-        )
-        self.assertFalse(ok)
+        with self.assertRaises(LuaError):
+            self.call(
+                "Bounce",
+                self.lua.table(nonce = self.nonce),
+                None,
+                1,
+                None,
+            )
 
     def test_bad_tag(self) -> None:
-        ok = self.call(
-            "Bounce",
-            self.lua.table(nonce = self.nonce),
-            None,
-            None,
-            1,
-        )
-        self.assertFalse(ok)
+        with self.assertRaises(LuaError):
+            self.call(
+                "Bounce",
+                self.lua.table(nonce = self.nonce),
+                None,
+                None,
+                1,
+            )
 
     def test_bad_self(self) -> None:
         with self.assertRaises(LuaError):

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -218,8 +218,8 @@ class TestLocationChecks(E2ETestCase):
             self.client["LocationChecks"](self.lua.table())
 
     def test_bad_locations(self) -> None:
-        res = self.call("LocationChecks", 1)
-        self.assertFalse(res)
+        with self.assertRaises(LuaError):
+            self.call("LocationChecks", 1)
 
 
 class TestLocationChecksNotConnected(NotConnectedTestCase):

--- a/test/test_connect_slot.py
+++ b/test/test_connect_slot.py
@@ -1,11 +1,12 @@
 """Test all variations of ConnectSlot command"""
 from .bases import E2ETestCase, ClientTestCase
+from .util import LuaError
 
 
 class Bases:
     class FailedConnect(E2ETestCase):
         def setUp(self) -> None:
-            with self.assertRaises(Exception):
+            with self.assertRaises(LuaError):
                 super().setUp()
 
         def tearDown(self) -> None:
@@ -89,7 +90,7 @@ class TestConnectVersionObject(E2ETestCase):
 
 class TestConnectInvalidVersion(Bases.FailedConnect):
     def _connect_slot(self) -> None:
-        res = self.call(
+        self.call(
             "ConnectSlot",
             self.slot,
             "",
@@ -97,57 +98,63 @@ class TestConnectInvalidVersion(Bases.FailedConnect):
             self.lua.table("Test"),
             self.lua.table(major="string"),
         )
-        # bad arg will just have ConnectSlot return non-true
-        self.assertFalse(res)
+        self.fail("call did not error")
 
 
 class TestConnectInvalidTags(Bases.FailedConnect):
     def _connect_slot(self) -> None:
-        res = self.call(
+        self.call(
             "ConnectSlot",
             self.slot,
             "",
             self.items_handling,
             self.lua.table(key="value"),
         )
-        # bad arg will just have ConnectSlot return non-true
-        self.assertFalse(res)
+        self.fail("call did not error")
 
 
 class TestConnectInvalidSlot(Bases.FailedConnect):
     def _connect_slot(self) -> None:
-        res = self.call(
+        self.call(
             "ConnectSlot",
             self.lua.table(bad="slot"),
             "",
             self.items_handling,
         )
-        # bad arg will just have ConnectSlot return non-true
-        self.assertFalse(res)
+        self.fail("call did not error")
 
 
 class TestConnectInvalidPassword(Bases.FailedConnect):
     def _connect_slot(self) -> None:
-        res = self.call(
+        self.call(
             "ConnectSlot",
             self.slot,
             self.lua.table(bad="password"),
             self.items_handling,
         )
-        # bad arg will just have ConnectSlot return non-true
-        self.assertFalse(res)
+        self.fail("call did not error")
 
 
 class TestConnectInvalidItemsHandling(Bases.FailedConnect):
     def _connect_slot(self) -> None:
-        res = self.call(
+        self.call(
             "ConnectSlot",
             self.slot,
             "",
             "bad items handling",
         )
-        # bad arg will just have ConnectSlot return non-true
-        self.assertFalse(res)
+        self.fail("call did not error")
+
+
+class TestConnectInvalidSelf(Bases.FailedConnect):
+    def _connect_slot(self) -> None:
+        self.client["ConnectSlot"](
+            self.lua.table(),
+            self.slot,
+            "",
+            self.items_handling,
+        )
+        self.fail("call did not error")
 
 
 class TestConnectUnconnected(ClientTestCase):

--- a/test/test_connect_socket.lua
+++ b/test/test_connect_socket.lua
@@ -1,7 +1,8 @@
 -- try to connect and disconnect (via GC) socket
 
+uri = arg[1] or "ws://localhost:38281"
 AP = require "lua-apclientpp"
-client = AP("", "", "ws://localhost:38281")  -- expect socket connected handler ...
+client = AP("", "", uri)  -- expect socket connected handler ...
 done = false
 
 function on_socket_connected()
@@ -25,6 +26,6 @@ if done then
     print("OK")
     os.exit(0)
 else
-    print("Timeout waiting for connect - is AP running on 38281?")
+    print("Timeout waiting for connect - is AP running on " .. uri .. " ?")
     os.exit(1)
 end

--- a/test/test_connect_update.py
+++ b/test/test_connect_update.py
@@ -1,8 +1,7 @@
 """Test all variations of ConnectUpdate command"""
 from typing import List
-from unittest import skipIf
 
-from .bases import E2ETestCase, ClientTestCase
+from .bases import E2ETestCase, NotConnectedTestCase
 from .util import LuaError, TimeoutLoop
 
 
@@ -14,8 +13,8 @@ class TestConnectUpdate(E2ETestCase):
         return self.server._connections[0].tags
 
     def test_update_nothing(self) -> None:
-        res = self.call("ConnectUpdate", None, None)
-        self.assertFalse(res)
+        with self.assertRaises(LuaError):
+            self.call("ConnectUpdate", None, None)
 
     def test_missing_arg1(self) -> None:
         with self.assertRaises(LuaError):
@@ -60,17 +59,11 @@ class TestConnectUpdate(E2ETestCase):
             self.call("ConnectUpdate", "a")
 
     def test_bad_tags(self) -> None:
-        res = self.call("ConnectUpdate", None, 1)
-        self.assertFalse(res)
+        with self.assertRaises(LuaError):
+            self.call("ConnectUpdate", None, 1)
 
 
-@skipIf(True, "FIXME: this currently crashes")
-class TestConnectUpdateNotConnected(ClientTestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.connect()
-
+class TestConnectUpdateNotConnected(NotConnectedTestCase):
     def test_update(self) -> None:
-        # FIXME: this throws an error but should just return false
         res = self.call("ConnectUpdate", 1, None)
         self.assertFalse(res)

--- a/test/test_exception.lua
+++ b/test/test_exception.lua
@@ -4,7 +4,13 @@
 -- - debug.stacktrace missing
 -- - debug missing
 
+uri = "ws://localhost:38289" -- nothing should be listening there
 AP = require "lua-apclientpp"
+
+function on_socket_connected()
+    print("Expected socket error")
+    os.exit(1)
+end
 
 function on_socket_error(reason)
     error("Test") -- return error ...
@@ -15,7 +21,8 @@ function bad_traceback()
 end
 
 for i = 1, 4 do
-    client = AP("", "", "ws://localhost:38289")
+    client = AP("", "", uri)
+    client:set_socket_connected_handler(on_socket_connected)
     client:set_socket_error_handler(on_socket_error)
 
     local t0 = os.clock()

--- a/test/test_properties.py
+++ b/test/test_properties.py
@@ -137,7 +137,79 @@ class TestProperties(E2ETestCase):
 class TestPropertiesNotConnected(ClientTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.connect()
+        self.connect()  # create instance but never poll to actually connect
+
+    def test_player_alias(self) -> None:
+        self.assertEqual("Server", self.call("get_player_alias", 0))
+        self.assertEqual("Unknown", self.call("get_player_alias", 1))
+
+    def test_negative_player_alias(self) -> None:
+        self.assertEqual("Unknown", self.call("get_player_alias", -1))
+
+    def test_player_game(self) -> None:
+        self.assertEqual("Archipelago", self.call("get_player_game", 0))
+        self.assertEqual("", self.call("get_player_game", 1))
+
+    def test_negative_player_game(self) -> None:
+        self.assertEqual("", self.call("get_player_game", -1))
+
+    def test_game(self) -> None:
+        self.assertEqual("", self.call("get_game"))
+
+    def test_location_name_unknown(self) -> None:
+        self.assertEqual("Unknown", self.call("get_location_name", 999999, self.game))
+        self.assertEqual("Unknown", self.call("get_location_name", 999999, None))
+        self.assertEqual("Unknown", self.call("get_location_name", 999999.0, None))
+
+    def test_location_id_unknown(self) -> None:
+        invalid_id = -1 * 2**63
+        self.assertEqual(invalid_id, self.call("get_location_id", "Nothing"))
+
+    def test_item_name_unknown(self) -> None:
+        self.assertEqual("Unknown", self.call("get_item_name", 999999, self.game))
+        self.assertEqual("Unknown", self.call("get_item_name", 999999, None))
+        self.assertEqual("Unknown", self.call("get_item_name", 999999.0, None))
+
+    def test_item_id_unknown(self) -> None:
+        invalid_id = -1 * 2**63
+        self.assertEqual(invalid_id, self.call("get_item_id", "Nothing"))
+
+    def test_state(self) -> None:
+        self.assertEqual(self.call("get_state"), self.client["State"]["SOCKET_CONNECTING"])
+
+    def test_seed(self) -> None:
+        self.assertEqual("", self.call("get_seed"))
+
+    def test_slot(self) -> None:
+        self.assertEqual("", self.call("get_slot"))
+
+    def test_player_number(self) -> None:
+        self.assertEqual(-1, self.call("get_player_number"))
+
+    def test_team_number(self) -> None:
+        self.assertEqual(-1, self.call("get_team_number"))
+
+    def test_hint_points(self) -> None:
+        self.assertEqual(0, self.call("get_hint_points"))
+
+    def test_hint_cost(self) -> None:
+        self.assertEqual(0, self.call("get_hint_cost_percent"))
+        self.assertEqual(0, self.call("get_hint_cost_points"))
+
+    def test_data_package_valid(self) -> None:
+        self.assertFalse(self.call("is_data_package_valid"))
+
+    def test_server_time(self) -> None:
+        t = self.call("get_server_time")
+        self.assertIsInstance(t, (int, float))
 
     def test_players(self) -> None:
         self.assertEqual(0, len(list(self.call("get_players").values())))
+
+    def test_checked_locations(self) -> None:
+        checked_locations = self.client["checked_locations"]
+        self.assertEqual(0, len(list(checked_locations.values())))
+
+    def test_missing_locations(self) -> None:
+        missing_locations = self.client["missing_locations"]
+        self.assertEqual(0, len(list(missing_locations.values())))

--- a/test/test_properties.py
+++ b/test/test_properties.py
@@ -122,7 +122,7 @@ class TestProperties(E2ETestCase):
 
     def test_missing_locations(self) -> None:
         # FIXME: this is currently empty
-        for k, v in self.client["checked_locations"].items():
+        for k, v in self.client["missing_locations"].items():
             self.assertIsInstance(k, int)
             self.assertIsInstance(v, int)
 

--- a/test/test_properties.py
+++ b/test/test_properties.py
@@ -7,11 +7,29 @@ class TestProperties(E2ETestCase):
         self.assertEqual("Server", self.call("get_player_alias", 0))
         self.assertEqual(self.slot, self.call("get_player_alias", 1))
         self.assertEqual("Unknown", self.call("get_player_alias", 999))
+        try:
+            self.assertEqual("Unknown", self.call("get_player_alias", 2**63 - 1))
+        except (OverflowError, LuaError):
+            pass  # might not work if lua_Integer isn't 64bit
+        try:
+            # TODO: assertRaises? currently doesn't raise on Lua < 5.4, but we get the correct result
+            self.assertEqual("Unknown", self.call("get_player_alias", float(2**63 - 1)))
+        except LuaError:
+            pass  # int -> float -> int is lossy, Lua 5.4 properly detects that
 
     def test_player_game(self) -> None:
         self.assertEqual("Archipelago", self.call("get_player_game", 0))
         self.assertEqual(self.game, self.call("get_player_game", 1))
         self.assertEqual("", self.call("get_player_game", 999), "Unknown game should be empty")
+        try:
+            self.assertEqual("", self.call("get_player_game", 2**63 - 1))
+        except (OverflowError, LuaError):
+            pass  # might not work if lua_Integer isn't 64bit
+        try:
+            # TODO: assertRaises? currently doesn't raise on Lua < 5.4, but we get the correct result
+            self.assertEqual("", self.call("get_player_game", float(2**63 - 1)))
+        except LuaError:
+            pass  # int -> float -> int is lossy, Lua 5.4 properly detects that
 
     def test_game(self) -> None:
         self.assertEqual(self.game, self.call("get_game"))

--- a/test/test_render_json.py
+++ b/test/test_render_json.py
@@ -12,7 +12,33 @@ class RenderJsonTest(ClientTestCase):
             self.client["render_json"]()
 
     def test_bad_data(self) -> None:
-        # bad data just returns nil
-        self.assertEqual(None, self.call("render_json", 1))
+        with self.assertRaises(LuaError):
+            self.call("render_json", 1)
+
+    def test_bad_format(self) -> None:
+        nodes = self.lua.table(self.lua.table())
+        with self.assertRaises(LuaError):
+            self.call("render_json", nodes, "bad")
+
+    def test_fallback_format(self) -> None:
+        nodes = self.lua.table(self.lua.table(text = "Test"))
+        fmt1 = self.client["RenderFormat"]["TEXT"]
+        text1 = self.call("render_json", nodes, fmt1)
+        self.assertTrue(text1)
+        fmt2 = 999
+        text2 = self.call("render_json", nodes, fmt2)
+        self.assertEqual(text1, text2)
+
+    def test_unsupported_format(self) -> None:
+        nodes = self.lua.table(self.lua.table())
+        fmt = self.client["RenderFormat"]["HTML"]
+        with self.assertRaises(LuaError):
+            res = self.call("render_json", nodes, fmt)
+            self.fail(f"render_json returned '{res}' instead of error")
+
+    def test_empty_data(self) -> None:
+        empty = self.client["EMPTY_ARRAY"]
+        res = self.call("render_json", empty)
+        self.assertEqual(res, "")
 
     # TODO: test plain, ansi, invalid

--- a/test/test_reset.py
+++ b/test/test_reset.py
@@ -1,8 +1,8 @@
-from test.bases import E2ETestCase
+from test.bases import E2ETestCase, ClientTestCase
 from test.util import LuaError, TimeoutLoop
 
 
-class ResetTest(E2ETestCase):
+class TestReset(E2ETestCase):
     done = False
 
     def on_room_info(self) -> None:
@@ -18,3 +18,14 @@ class ResetTest(E2ETestCase):
     def test_bad_call(self) -> None:
         with self.assertRaises(LuaError):
             self.client["reset"](self.lua.table())
+
+
+class TestResetNotConnected(ClientTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.connect()
+        # don't poll, so never actually connect
+
+    def test_reset(self) -> None:
+        res = self.call("reset")
+        self.assertFalse(res)  # nil


### PR DESCRIPTION
* bad arguments (wrong type) should now consistently return an error
* running commands that need a network connection now consistently return `false` or falsy if unconnected
* render_json now always returns a string (or throws an error)
* this should now match the api/library/lua-apclientpp.lua API doc
* add and update a bunch of tests to verify all of the above

Also
  * fixes the missing_locations test (had a typo)
  * adds mypy to CI to make it less likely to write "wrong" tests.
  * makes the test_exe test more resilient by picking a random port.
  * fixes some warnings / inefficiencies in the C++ code.
  * fixes some warnings / problems with integer conversion in the C++ code.
    * NOTE: there is still an inconsistency when passing integers as float that can't be represented properly. Should not have any practical relevance though. Lua 5.4 kinda gets it right and Lua < 5.4 not.