### PR TITLE
Improve supply chain security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,11 @@ updates:
       default-days: 3
       include:
         - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 3
+      include:
+        - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/test"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
+      include:
+        - "*"
     groups:
       python-packages:
         patterns:
@@ -12,3 +16,7 @@ updates:
     directory: "/.github"  # packages only used in CI (relink)
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
+      include:
+        - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,14 @@ updates:
       include:
         - "*"
     groups:
-      python-packages:
+      lupa:
+        patterns:
+          - "lupa"
+      other-python-packages:
         patterns:
           - "*"
+        exclude-patterns:
+          - "lupa"
   - package-ecosystem: "pip"
     directory: "/.github"  # packages only used in CI (relink)
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
       python-packages:
         patterns:
           - "*"
+  - package-ecosystem: "pip"
+    directory: "/.github"  # packages only used in CI (relink)
+    schedule:
+      interval: "weekly"

--- a/.github/requirements-relink.txt
+++ b/.github/requirements-relink.txt
@@ -1,0 +1,2 @@
+machomachomangler==0.0.1
+mingw_ldd==0.2.1

--- a/.github/workflows/build-msbuild.yaml
+++ b/.github/workflows/build-msbuild.yaml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           submodules: recursive
 
@@ -49,7 +49,7 @@ jobs:
           Start-Process -FilePath ./vs_BuildTools.exe -ArgumentList "--add", "Microsoft.VisualStudio.Component.VC.v141.x86.x64", "--add", "Microsoft.VisualStudio.Component.VC.v141.CLI.Support", "--quiet", "--norestart", "--force", "--wait" -Wait -PassThru
 
       - name: MSVC Dev Cmd 14.0
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756  # v1.13.0
         if: |
           matrix.sln == 'vs2015'
         with:
@@ -57,7 +57,7 @@ jobs:
           toolset: '14.0'
 
       - name: MSVC Dev Cmd 14.1
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756  # v1.13.0
         if: |
           matrix.sln == 'vs2017'
         with:
@@ -65,17 +65,17 @@ jobs:
           toolset: '14.1'
 
       - name: MSVC Dev Cmd (Default)
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756  # v1.13.0
         if: |
           matrix.sln == 'vs2022'
         with:
           arch: ${{env.ARCH}}
 
       - name: Install NASM
-        uses: ilammy/setup-nasm@v1
+        uses: ilammy/setup-nasm@13cbeb366c45c4379d3478cdcbadd8295feb5028  # v1.5.1
 
       - name: Install Perl
-        uses: shogo82148/actions-setup-perl@v1
+        uses: shogo82148/actions-setup-perl@v1.40.0  # immutable release
 
       - name: Build OpenSSL
         run: |
@@ -128,7 +128,7 @@ jobs:
       - name: Add MSBuild to PATH
         if: |
           matrix.sln == 'vs2017'
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57  # v3.0.0
 
       - name: Build for Lua 5.1 Dynamic
         run: |
@@ -137,7 +137,7 @@ jobs:
           move ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}\lua-apclientpp-51-dynamic.dll ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}\lua51\lua-apclientpp.dll
 
       - name: Store Lua 5.1 Dynamic
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: lua-apclientpp-lua51-${{matrix.sln}}-${{env.ARCH}}-dynamic
           path: ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}\lua51\lua-apclientpp.dll
@@ -150,7 +150,7 @@ jobs:
           move ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}\lua-apclientpp-52-dynamic.dll ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}\lua52\lua-apclientpp.dll
 
       - name: Store Lua 5.2 Dynamic
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: lua-apclientpp-lua52-${{matrix.sln}}-${{env.ARCH}}-dynamic
           path: ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}\lua52\lua-apclientpp.dll
@@ -163,7 +163,7 @@ jobs:
           move ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}\lua-apclientpp-52-static.dll ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}\lua52-static\lua-apclientpp.dll
 
       - name: Store Lua 5.2 Static
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: lua-apclientpp-lua52-${{matrix.sln}}-${{env.ARCH}}-static
           path: ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}\lua52-static\lua-apclientpp.dll
@@ -176,7 +176,7 @@ jobs:
           move ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}\lua-apclientpp-53-dynamic.dll ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}\lua53\lua-apclientpp.dll
 
       - name: Store Lua 5.3 Dynamic
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: lua-apclientpp-lua53-${{matrix.sln}}-${{env.ARCH}}-dynamic
           path: ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}\lua53\lua-apclientpp.dll
@@ -189,7 +189,7 @@ jobs:
           move ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}\lua-apclientpp-53-static.dll ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}\lua53-static\lua-apclientpp.dll
 
       - name: Store Lua 5.3 Static
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: lua-apclientpp-lua53-${{matrix.sln}}-${{env.ARCH}}-static
           path: ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}\lua53-static\lua-apclientpp.dll
@@ -202,7 +202,7 @@ jobs:
           move ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}\lua-apclientpp-54-dynamic.dll ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}\lua54\lua-apclientpp.dll
 
       - name: Store Lua 5.4 Dynamic
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: lua-apclientpp-lua54-${{matrix.sln}}-${{env.ARCH}}-dynamic
           path: ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}\lua54\lua-apclientpp.dll
@@ -215,7 +215,7 @@ jobs:
           move ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}\lua-apclientpp-54-static.dll ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}\lua54-static\lua-apclientpp.dll
 
       - name: Store Lua 5.4 Static
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: lua-apclientpp-lua54-${{matrix.sln}}-${{env.ARCH}}-static
           path: ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}\lua54-static\lua-apclientpp.dll

--- a/.github/workflows/build-msbuild.yaml
+++ b/.github/workflows/build-msbuild.yaml
@@ -28,6 +28,10 @@ jobs:
           - os: windows-2022
             sln: vs2022
 
+    permissions:
+      id-token: write
+      attestations: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6.0.2
@@ -220,3 +224,8 @@ jobs:
           name: lua-apclientpp-lua54-${{matrix.sln}}-${{env.ARCH}}-static
           path: ${{matrix.sln}}\${{env.BUILD_CONFIGURATION}}\lua54-static\lua-apclientpp.dll
           if-no-files-found: error
+
+      - name: Attest built DLLs
+        uses: actions/attest@v4.1.0
+        with:
+          subject-path: '${{matrix.sln}}/${{env.BUILD_CONFIGURATION}}/*/lua-apclientpp.dll'

--- a/.github/workflows/build-msbuild.yaml
+++ b/.github/workflows/build-msbuild.yaml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions: {}
+
 jobs:
   build-msbuild:
     # TODO: automated testing

--- a/.github/workflows/build-msys2.yaml
+++ b/.github/workflows/build-msys2.yaml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           submodules: recursive
 
@@ -60,7 +60,7 @@ jobs:
 
       - name: Install MSYS ${{matrix.sys}} + gcc
         if: ${{ !startsWith(matrix.sys, 'clang') }}
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@cafece8e6baf9247cf9b1bf95097b0b983cc558d  # v2.31.0
         with:
           msystem: ${{matrix.sys}}
           # update: true
@@ -68,7 +68,7 @@ jobs:
 
       - name: Install MSYS ${{matrix.sys}} + clang + gcc-wrapper
         if: ${{ startsWith(matrix.sys, 'clang') }}
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@cafece8e6baf9247cf9b1bf95097b0b983cc558d  # v2.31.0
         with:
           msystem: ${{matrix.sys}}
           # update: true
@@ -102,7 +102,7 @@ jobs:
           ./build_posix.sh ${{env.LUA_VERSION}}
 
       - name: Store ${{env.LUA_NAME}}-dynamic
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: lua-apclientpp-${{env.LUA_NAME}}-${{matrix.sys}}-dynamic
           path: lua-apclientpp.dll
@@ -119,7 +119,7 @@ jobs:
           ./build_posix.sh ${{env.LUA_VERSION}} static
 
       - name: Store ${{env.LUA_NAME}}-static
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: lua-apclientpp-${{env.LUA_NAME}}-${{matrix.sys}}-static
           path: lua-apclientpp.dll

--- a/.github/workflows/build-msys2.yaml
+++ b/.github/workflows/build-msys2.yaml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions: {}
+
 jobs:
   build-msys2:
     # TODO: automated testing

--- a/.github/workflows/build-msys2.yaml
+++ b/.github/workflows/build-msys2.yaml
@@ -31,6 +31,10 @@ jobs:
     env:
       DEFAULT_LUA: 5.4
 
+    permissions:
+      id-token: write
+      attestations: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -100,12 +104,14 @@ jobs:
         run: |
           rm -f *.dll
           ./build_posix.sh ${{env.LUA_VERSION}}
+          mkdir -p built/dynamic
+          mv lua-apclientpp.dll built/dynamic/
 
       - name: Store ${{env.LUA_NAME}}-dynamic
         uses: actions/upload-artifact@v7.0.0
         with:
           name: lua-apclientpp-${{env.LUA_NAME}}-${{matrix.sys}}-dynamic
-          path: lua-apclientpp.dll
+          path: built/dynamic/lua-apclientpp.dll
 
       - name: Rename liblua.a -> lib${{env.LUA_NAME}}.a
         if: |
@@ -117,9 +123,16 @@ jobs:
         run: |
           rm -f *.dll
           ./build_posix.sh ${{env.LUA_VERSION}} static
+          mkdir -p built/static
+          mv lua-apclientpp.dll built/static/
 
       - name: Store ${{env.LUA_NAME}}-static
         uses: actions/upload-artifact@v7.0.0
         with:
           name: lua-apclientpp-${{env.LUA_NAME}}-${{matrix.sys}}-static
-          path: lua-apclientpp.dll
+          path: built/static/lua-apclientpp.dll
+
+      - name: Attest built DLLs
+        uses: actions/attest@v4.1.0
+        with:
+          subject-path: 'built/*/lua-apclientpp.dll'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,8 @@ on:
     tags:
       - 'v*'
 
+permissions: {}
+
 jobs:
 
   build-msys2:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,9 +28,16 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Checkout requirements file
+        uses: actions/checkout@v6.0.2
+        with:
+          sparse-checkout: |
+            .github/requirements-relink.txt
+          sparse-checkout-cone-mode: false
+
       - name: Install dependencies
         run: |
-          pip install --upgrade machomachomangler mingw_ldd
+          pip install -r .github/requirements-relink.txt
 
       - name: Load lua53-vs2022-win32-dynamic
         uses: actions/download-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Install python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: '3.14'
 
@@ -40,7 +40,7 @@ jobs:
           pip install -r .github/requirements-relink.txt
 
       - name: Load lua53-vs2022-win32-dynamic
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: lua-apclientpp-lua53-vs2022-win32-dynamic
 
@@ -52,13 +52,13 @@ jobs:
           python -m mingw_ldd lua-apclientpp.dll --dll-lookup-dirs . | grep lua
 
       - name: Store lua533r-vs2022-win32-dynamic
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: lua-apclientpp-lua533r-vs2022-win32-dynamic
           path: lua-apclientpp.dll
 
       - name: Load lua51-vs2022-win32-dynamic
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: lua-apclientpp-lua51-vs2022-win32-dynamic
 
@@ -69,7 +69,7 @@ jobs:
           python -m mingw_ldd lua-apclientpp.dll --dll-lookup-dirs . | grep lua
 
       - name: Store lua51-51-vs2022-win32-dynamic
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: lua-apclientpp-lua51-51-vs2022-win32-dynamic
           path: lua-apclientpp.dll
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           submodules: recursive
 
@@ -101,7 +101,7 @@ jobs:
           cat subprojects/wswrap/LICENSE >> lua-apclientpp-license.txt
 
       - name: Store
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: lua-apclientpp-license
           path: lua-apclientpp-license.txt

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,16 +11,28 @@ permissions: {}
 jobs:
 
   build-msys2:
+    permissions:
+      id-token: write
+      attestations: write
+
     uses: ./.github/workflows/build-msys2.yaml
 
 
   build-msbuild:
+    permissions:
+      id-token: write
+      attestations: write
+
     uses: ./.github/workflows/build-msbuild.yaml
 
 
   relink:
     needs: [build-msys2, build-msbuild]
     runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      attestations: write
 
     steps:
       - name: Install python
@@ -50,12 +62,15 @@ jobs:
           mv lua-apclientpp.dll _lua-apclientpp.dll
           python -m machomachomangler.cmd.redll _lua-apclientpp.dll lua-apclientpp.dll lua53.dll Lua5.3.3r.dll
           python -m mingw_ldd lua-apclientpp.dll --dll-lookup-dirs . | grep lua
+          sha256sum _lua-apclientpp.dll lua-apclientpp.dll
+          mkdir -p relink/lua533r-vs2022-win32-dynamic
+          mv lua-apclientpp.dll relink/lua533r-vs2022-win32-dynamic/
 
       - name: Store lua533r-vs2022-win32-dynamic
         uses: actions/upload-artifact@v7.0.0
         with:
           name: lua-apclientpp-lua533r-vs2022-win32-dynamic
-          path: lua-apclientpp.dll
+          path: relink/lua533r-vs2022-win32-dynamic/lua-apclientpp.dll
 
       - name: Load lua51-vs2022-win32-dynamic
         uses: actions/download-artifact@v8.0.1
@@ -67,13 +82,20 @@ jobs:
           mv lua-apclientpp.dll _lua-apclientpp.dll
           python -m machomachomangler.cmd.redll _lua-apclientpp.dll lua-apclientpp.dll lua5.1.dll lua51.dll
           python -m mingw_ldd lua-apclientpp.dll --dll-lookup-dirs . | grep lua
+          sha256sum _lua-apclientpp.dll lua-apclientpp.dll
+          mkdir -p relink/lua51-51-vs2022-win32-dynamic
+          mv lua-apclientpp.dll relink/lua51-51-vs2022-win32-dynamic/
 
       - name: Store lua51-51-vs2022-win32-dynamic
         uses: actions/upload-artifact@v7.0.0
         with:
           name: lua-apclientpp-lua51-51-vs2022-win32-dynamic
-          path: lua-apclientpp.dll
+          path: relink/lua51-51-vs2022-win32-dynamic/lua-apclientpp.dll
 
+      - name: Attest relinked DLLs
+        uses: actions/attest@v4.1.0
+        with:
+          subject-path: 'relink/*/lua-apclientpp.dll'
 
   license-copy-paste:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.14'
 
       - name: Checkout requirements file
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
           sudo apt-get install coreutils build-essential libssl-dev liblua${{ matrix.lua }}-dev lua${{ matrix.lua }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           submodules: recursive
 
@@ -105,7 +105,7 @@ jobs:
           --json coverage-${{ matrix.lua }}.json
 
       - name: Upload Coverage Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: 'coverage-${{ matrix.lua }}.json'
           path: 'coverage-${{ matrix.lua }}.json'
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Install dependencies
         run: >
@@ -133,14 +133,14 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Install dependencies
         run: >
           pip install
           -r test/requirements-dev.txt
 
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v8.0.1
         with:
           pattern: 'coverage-*.json'
           merge-multiple: true
@@ -152,7 +152,7 @@ jobs:
           --html-details coverage.html
 
       - name: Upload HTML Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: 'coverage'
           path: 'coverage.*'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
           - 5.3
           - 5.4
         os:
-          - 'ubuntu-latest'
+          - 'ubuntu-24.04'
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -113,7 +113,7 @@ jobs:
           if-no-files-found: 'error'
 
   type-check-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -130,7 +130,7 @@ jobs:
 
   coverage-report:
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,8 @@ on:
       - '!**.yaml'
       - '.github/workflows/ci.yaml'
 
+permissions: {}
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -4,6 +4,8 @@ on:
   push:
   pull_request:
 
+permissions: {}
+
 jobs:
   codespell:
     runs-on: ubuntu-latest

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -12,8 +12,8 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           submodules: recursive
 
-      - uses: codespell-project/actions-codespell@v2
+      - uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,13 +40,13 @@ jobs:
 
     steps:
       - name: Grab README
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           path: src
 
       - name: Download ${{ matrix.lua }} Artifacts
         id: download-artifact
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@8a338493df3d275e4a7a63bcff3b8fe97e51a927  # v19
         with:
           workflow: build.yaml
           name: ${{ matrix.lua }}|license
@@ -66,7 +66,7 @@ jobs:
           7z a -mx=9 -ms=on ${{ matrix.lua }}.7z ${{ matrix.lua }}
 
       - name: Upload ${{ matrix.lua }} Bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: ${{ matrix.lua }}
           path: ${{ matrix.lua }}.7z

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,10 @@
 
 name: Release
 
-on: workflow_dispatch
+on: workflow_dispatch  # NOTE: build happens automatically on tag push, release is triggered manually
+
+permissions:
+  contents: write  # required to add to releases
 
 jobs:
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Changing it may require stripping the DLL, which is done for the automated build
 
 ```bash
 # strip lua-apclientpp.dll  # strip the build (i686-w64-mingw32-strip or whatever)
-pip install machomachomangler mingw_ldd
+pip install machomachomangler mingw_ldd  # or -r .github/requirements-relink.txt
 mv lua-apclientpp.dll _lua-apclientpp.dll # rename the original
 # replace lua53.dll and lua53.3r.dll with the original and correct names below
 python -m machomachomangler.cmd.redll _lua-apclientpp.dll lua-apclientpp.dll lua53.dll Lua5.3.3r.dll


### PR DESCRIPTION
* use `permissions:` everywhere to limit access
* pin versions and enable dependabot for relink requirements
* update most + pin all versions and enable dependabot for github actions
  * `actions/*` are pinned to versions (hopefully using immutable actions preview or moving to immutable tags on day)
  * other actions are pinned tag if immutable or hash otherwise
  * all versions besides `dawidd6/action-download-artifact` we use elsewhere[^1] or were **briefly** reviewed
* use attestation for the built DLLs so we can check release artifacts to reducing risk of stuff happening in the release step
* print hashes in relink
* split lupa and other python package upgrades for to avoid having stale dependabot PRs we don't want to merge (yet)
* use known-good ubuntu-24.04 in tests
* update python in tests to latest stable (3.11 doesn't get regular releases anymore)
* set cooldown for dependabot updates

Note: there are at least 2 actions that have not updated to node24 yet
Note: we should also enable CodeQL, but that'll be done via repo settings.

Tested here: https://github.com/black-sliver/lua-apclientpp/actions/runs/24309372578

[^1]: other projects I maintain or co-maintain