### PR TITLE
CI: disable mingw32

### DIFF
--- a/.github/workflows/build-msys2.yaml
+++ b/.github/workflows/build-msys2.yaml
@@ -15,7 +15,7 @@ jobs:
         sys:
           #- clang32
           - clang64
-          - mingw32
+          #- mingw32
           - mingw64
           - ucrt64
         lua:


### PR DESCRIPTION
This is being phased out by msys2.
Hopefully nobody depends on this, otherwise we have to build bunch of stuff ourselves.