### PR TITLE
Partial lua5.5 support

### DIFF
--- a/extra_pkgconf.sh
+++ b/extra_pkgconf.sh
@@ -13,7 +13,7 @@
 
 if [ "$LUA" = "lua" ]; then
     # try to get the version from the standard include
-    LUA="$(printf '#include <lua.h>\nLUA_VERSION\n' | $CC $(pkg-config --cflags lua) -E - | tail -n1 | sed 's/[\t "]//g' | tr '[:upper:]' '[:lower:]')"
+    LUA="$(printf '#include <lua.h>\nLUA_VERSION\n' | $CC $(pkg-config --cflags lua) -P -E - | tail -n1 | sed 's/[\t "]//g' | tr '[:upper:]' '[:lower:]')"
 fi
 
 # NOTE: we keep the '.' because MSYS requires it

--- a/test/util.py
+++ b/test/util.py
@@ -25,6 +25,14 @@ sys.setdlopenflags(258)
 is_jit = False
 lua_exe: Optional[str] = None
 
+if not lua_version:
+    # try to detect default lua
+    import subprocess
+    default_lua_exe = which("lua")
+    if default_lua_exe:
+        res = subprocess.run([default_lua_exe, "-v"], capture_output=True, text=True)
+        lua_version = ".".join(res.stdout.split(" ")[1].split(".")[:2])
+
 if lua_version == "5.4":
     from lupa.lua54 import LuaError, LuaRuntime
     lua_exe = which("lua5.4")

--- a/test/util.py
+++ b/test/util.py
@@ -33,7 +33,9 @@ if not lua_version:
         res = subprocess.run([default_lua_exe, "-v"], capture_output=True, text=True)
         lua_version = ".".join(res.stdout.split(" ")[1].split(".")[:2])
 
-if lua_version == "5.4":
+if lua_version == "5.5":
+    raise ValueError("lua5.5 not supported in tests yet")
+elif lua_version == "5.4":
     from lupa.lua54 import LuaError, LuaRuntime
     lua_exe = which("lua5.4")
 elif lua_version == "5.3":
@@ -49,9 +51,15 @@ elif lua_version == "JIT2.1":
     from lupa.luajit21 import LuaError, LuaRuntime  # type: ignore[assignment]
     lua_exe = which("luajit2") or which("luajit")
     is_jit = True
-else:  # default to 5.4
-    from lupa.lua54 import LuaError, LuaRuntime
+elif not lua_version:
+    # if 5.4 is missing and 5.5 is available, assume default is 5.5
     lua_exe = which("lua5.4")
+    if not lua_exe and which("lua5.5"):
+        raise ValueError("lua5.5 not supported in tests yet")
+    # otherwise assume default is 5.4
+    from lupa.lua54 import LuaError, LuaRuntime
+else:
+    raise ValueError(f"Unsupported Lua version: {lua_version}")
 
 sys.setdlopenflags(_orig_dlflags)
 


### PR DESCRIPTION
* fix detection of default Lua being 5.5 if unspecified
* try to detect the default Lua version in tests (instead of assuming 5.4)
* error out tests if the Lua version is unsupported